### PR TITLE
feat: implementando action types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,7 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': [
-        'warn',
+        'off',
         { allowConstantExport: true },
       ],
     },

--- a/src/contexts/CyclesContext.tsx
+++ b/src/contexts/CyclesContext.tsx
@@ -1,13 +1,5 @@
 import { createContext, ReactNode, useReducer, useState } from "react";
-
-interface Cycle {
-	id: string;
-	task: string;
-	minutesAmount: number;
-	startDate: Date;
-	interruptedDate?: Date;
-	finishedDate?: Date;
-}
+import { ActionTypes, Cycle, cyclesReducer } from "../reducers/cycles";
 
 interface CreateCycleData {
 	task: string;
@@ -32,85 +24,15 @@ interface CyclesContextProviderProps {
 	children: ReactNode;
 }
 
-interface CyclesState {
-	cycles: Cycle[];
-	activeCycleId: string | null;
-}
-
 export const CyclesContext = createContext({} as CyclesContextType);
 
 export function CyclesContextProvider({
 	children,
 }: CyclesContextProviderProps) {
-	/**
-	 * Utilizando useReducer para atualização do estado dos ciclos.
-	 * @param state - O estado atual da lista de ciclos. Representa a variável `cycles` dentro da função `reducer`.
-	 * @param action - A ação que será realizada sobre o estado (por exemplo, adicionar um novo ciclo).
-	 *
-	 * @returns - O retorno do useReducer é o novo valor que o estado cycles irá receber
-	 *
-	 * O nome `dispatch` é utilizado por convenção, pois é o método responsável por enviar as ações para o `reducer`.
-	 * Ele permite que o estado seja atualizado de acordo com as ações disparadas.
-	 * A alteração do nome da função para `dispatch` segue a convenção do React e facilita a compreensão
-	 * do código por outros desenvolvedores familiarizados com essa prática.
-	 */
-	const [cyclesState, dispatch] = useReducer(
-		(state: CyclesState, action: any) => {
-			switch (action.type) {
-				/**
-				 * Retorna um objeto contendo os estados anteriores, com um array de ciclos
-				 * e adiciona um novo ciclo ao final. Por fim, define o novo ciclo como ativo.
-				 */
-				case "ADD_NEW_CYCLE":
-					return {
-						...state,
-						cycles: [...state.cycles, action.payload.newCycle],
-						activeCycleId: action.payload.newCycle.id,
-					};
-				case "INTERRUPT_CURRENT_CYCLE":
-					// Verifica se a ação é de interromper o ciclo ativo
-					return {
-						...state, // Mantém todos os estados anteriores inalterados
-						cycles: state.cycles.map((cycle) => {
-							// Mapeia todos os ciclos
-							if (cycle.id === state.activeCycleId) {
-								// Verifica se o ciclo é o ciclo ativo
-								return {
-									...cycle, // Faz uma cópia do ciclo
-									interruptedDate: new Date(), // Adiciona a data de interrupção no ciclo ativo
-								};
-							} else {
-								return cycle; // Retorna o ciclo inalterado se não for o ciclo ativo
-							}
-						}),
-						activeCycleId: null, // Define o ciclo ativo como nulo, indicando que não há ciclo ativo
-					};
-				case "MARK_CURRENT_CYCLE_AS_FINISHED":
-					return {
-						...state, // Mantém todos os estados anteriores inalterados
-						cycles: state.cycles.map((cycle) => {
-							// Mapeia todos os ciclos
-							if (cycle.id === state.activeCycleId) {
-								// Verifica se o ciclo é o ciclo ativo
-								return {
-									...cycle, // Faz uma cópia do ciclo
-									finishedDate: new Date(), // Adiciona a data de finalização no ciclo ativo
-								};
-							} else {
-								return cycle; // Retorna o ciclo inalterado se não for o ciclo ativo
-							}
-						}),
-						activeCycleId: null, // Define o ciclo ativo como nulo, indicando que não há ciclo ativo
-					};
-				default:
-					return state;
-			}
-		},
-		{
-			cycles: [],
-			activeCycleId: null,
-		}
-	);
+	const [cyclesState, dispatch] = useReducer(cyclesReducer, {
+		cycles: [],
+		activeCycleId: null,
+	});
 
 	const [amountSecondsPassed, setAmountSecondsPassed] = useState(0);
 
@@ -124,7 +46,7 @@ export function CyclesContextProvider({
 
 	function markCurrentCycleAsFinished() {
 		dispatch({
-			type: "MARK_CURRENT_CYCLE_AS_FINISHED",
+			type: ActionTypes.MARK_CURRENT_CYCLE_AS_FINISHED,
 			payload: {
 				activeCycleId,
 			},
@@ -145,7 +67,7 @@ export function CyclesContextProvider({
 		};
 
 		dispatch({
-			type: "ADD_NEW_CYCLE",
+			type: ActionTypes.ADD_NEW_CYCLE,
 			payload: {
 				newCycle,
 			},
@@ -167,7 +89,7 @@ export function CyclesContextProvider({
 	 */
 	function interruptCurrentCycle() {
 		dispatch({
-			type: "INTERRUPT_CURRENT_CYCLE",
+			type: ActionTypes.INTERRUPT_CURRENT_CYCLE,
 			payload: {
 				activeCycleId,
 			},

--- a/src/reducers/cycles.ts
+++ b/src/reducers/cycles.ts
@@ -1,0 +1,83 @@
+export interface Cycle {
+	id: string;
+	task: string;
+	minutesAmount: number;
+	startDate: Date;
+	interruptedDate?: Date;
+	finishedDate?: Date;
+}
+
+interface CyclesState {
+	cycles: Cycle[];
+	activeCycleId: string | null;
+}
+
+export enum ActionTypes {
+	ADD_NEW_CYCLE = "ADD_NEW_CYCLE",
+	INTERRUPT_CURRENT_CYCLE = "INTERRUPT_CURRENT_CYCLE",
+	MARK_CURRENT_CYCLE_AS_FINISHED = "MARK_CURRENT_CYCLE_AS_FINISHED",
+}
+
+/**
+ * Utilizando useReducer para atualização do estado dos ciclos.
+ * @param state - O estado atual da lista de ciclos. Representa a variável `cycles` dentro da função `reducer`.
+ * @param action - A ação que será realizada sobre o estado (por exemplo, adicionar um novo ciclo).
+ *
+ * @returns - O retorno do useReducer é o novo valor que o estado cycles irá receber
+ *
+ * O nome `dispatch` é utilizado por convenção, pois é o método responsável por enviar as ações para o `reducer`.
+ * Ele permite que o estado seja atualizado de acordo com as ações disparadas.
+ * A alteração do nome da função para `dispatch` segue a convenção do React e facilita a compreensão
+ * do código por outros desenvolvedores familiarizados com essa prática.
+ */
+export function cyclesReducer(state: CyclesState, action: any) {
+	switch (action) {
+		/**
+		 * Retorna um objeto contendo os estados anteriores, com um array de ciclos
+		 * e adiciona um novo ciclo ao final. Por fim, define o novo ciclo como ativo.
+		 */
+		case ActionTypes.ADD_NEW_CYCLE:
+			return {
+				...state,
+				cycles: [...state.cycles, action.payload.newCycle],
+				activeCycleId: action.payload.newCycle.id,
+			};
+		case ActionTypes.INTERRUPT_CURRENT_CYCLE:
+			// Verifica se a ação é de interromper o ciclo ativo
+			return {
+				...state, // Mantém todos os estados anteriores inalterados
+				cycles: state.cycles.map((cycle) => {
+					// Mapeia todos os ciclos
+					if (cycle.id === state.activeCycleId) {
+						// Verifica se o ciclo é o ciclo ativo
+						return {
+							...cycle, // Faz uma cópia do ciclo
+							interruptedDate: new Date(), // Adiciona a data de interrupção no ciclo ativo
+						};
+					} else {
+						return cycle; // Retorna o ciclo inalterado se não for o ciclo ativo
+					}
+				}),
+				activeCycleId: null, // Define o ciclo ativo como nulo, indicando que não há ciclo ativo
+			};
+		case ActionTypes.MARK_CURRENT_CYCLE_AS_FINISHED:
+			return {
+				...state, // Mantém todos os estados anteriores inalterados
+				cycles: state.cycles.map((cycle) => {
+					// Mapeia todos os ciclos
+					if (cycle.id === state.activeCycleId) {
+						// Verifica se o ciclo é o ciclo ativo
+						return {
+							...cycle, // Faz uma cópia do ciclo
+							finishedDate: new Date(), // Adiciona a data de finalização no ciclo ativo
+						};
+					} else {
+						return cycle; // Retorna o ciclo inalterado se não for o ciclo ativo
+					}
+				}),
+				activeCycleId: null, // Define o ciclo ativo como nulo, indicando que não há ciclo ativo
+			};
+		default:
+			return state;
+	}
+}


### PR DESCRIPTION
## **Descrição:**

criação de um enum para separar as nossas actions.

## Alterações feitas:

* Implementação de action types, ajudando na manutenção do código e facilitando a chamada em possíveis casos que podemos esquecer nome que foi dado a ela.
* Concentrando o nossa função reducer em uma pasta e chamando a função exportada no hook useReducer.

## **Motivo da alteração:**

* Melhorar legibilidade, organização e manutenção do código.